### PR TITLE
How to navigate to the multiple controls loaded in GridTemplateColumn by Tab Key in WPF DataGrid (SfDataGrid)?

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ How to navigate to the multiple controls loaded in GridTemplateColumn by Tab Key
 
 # About the sample
 
-By default, SfDataGrid does not provide the support to navigate multiple controls loaded in GridTemplateColumn by Tab key, you can achieve this by overriding ShouldGridTryToHandleKeyDown method in GridCellTemplateRenderer.
+By default, SfDataGrid does not support navigation to the controls inside GridTemplateColumn, you can achieve this by overriding ShouldGridTryToHandleKeyDown method in GridCellTemplateRenderer.
 
 ```c#
 public class SfDataGridBehavior : Behavior<SfDataGrid>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
-# how-to-navigate-to-the-multiple-controls-loaded-in-gridtemplatecolumn-by-tab-Key-in-wpf-datagrid
+# How to navigate to the multiple controls loaded in GridTemplateColumn by Tab Key in WPF DataGrid (SfDataGrid)?
+
 How to navigate to the multiple controls loaded in GridTemplateColumn by Tab Key in WPF DataGrid (SfDataGrid)?
+
+# About the sample
+
+```c#
+public class SfDataGridBehavior : Behavior<SfDataGrid>
+{
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        this.AssociatedObject.CellRenderers.Remove("Template");
+        this.AssociatedObject.CellRenderers.Add("Template", new CustomGridCellTemplateRenderer());
+    }
+}
+
+public class CustomGridCellTemplateRenderer : GridCellTemplateRenderer
+{
+    private FrameworkElement PreviousCurrentCellElement = null;
+    public CustomGridCellTemplateRenderer()
+    {
+
+    }
+
+    protected override bool ShouldGridTryToHandleKeyDown(KeyEventArgs e)
+    {
+        if (e.Key != Key.Tab)
+            return base.ShouldGridTryToHandleKeyDown(e);
+
+        bool isShiftPressed = SelectionHelper.CheckShiftKeyPressed();
+        UIElement currentFocusedElement = Keyboard.FocusedElement as UIElement;
+        var currentCell = this.DataGrid.SelectionController.CurrentCellManager.CurrentCell;
+        var columnElement = currentCell.ColumnElement;
+        //Column with Multiple controls inside DataTemplate.
+        if (currentCell.GridColumn.MappingName != "SalesID")
+            return base.ShouldGridTryToHandleKeyDown(e);
+        if (PreviousCurrentCellElement != columnElement && currentFocusedElement is SfDataGrid)
+        {
+            FocusNavigationDirection focusNavigationDirection = isShiftPressed ? FocusNavigationDirection.Last : FocusNavigationDirection.First;
+            TraversalRequest tRequest = new TraversalRequest(focusNavigationDirection);
+            //To navigate from other column to template column
+            if (columnElement.MoveFocus(tRequest))
+            {
+                e.Handled = true;
+                PreviousCurrentCellElement = columnElement;
+                return false;
+            }
+        }
+        else
+        {
+            FocusNavigationDirection focusNavigationDirection = isShiftPressed ? FocusNavigationDirection.First : FocusNavigationDirection.Last;
+            TraversalRequest traversalRequest = new TraversalRequest(focusNavigationDirection);
+            if (columnElement.MoveFocus(traversalRequest))
+            {
+                if (Keyboard.FocusedElement != currentFocusedElement)
+                {
+                    Keyboard.Focus(currentFocusedElement);
+                    PreviousCurrentCellElement = columnElement;
+                    return false;
+                }
+                //To navigate to other columns from template column
+                else
+                {
+                    Keyboard.Focus(currentFocusedElement);
+                    PreviousCurrentCellElement = null;
+                    return base.ShouldGridTryToHandleKeyDown(e);
+                }
+            }
+        }
+
+        PreviousCurrentCellElement = columnElement;
+        return base.ShouldGridTryToHandleKeyDown(e);
+    }
+}
+```
+## Requirements to run the demo
+ Visual Studio 2015 and above versions

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ How to navigate to the multiple controls loaded in GridTemplateColumn by Tab Key
 
 # About the sample
 
+By default, SfDataGrid does not provide the support to navigate multiple controls loaded in GridTemplateColumn by Tab key, you can achieve this by overriding ShouldGridTryToHandleKeyDown method in GridCellTemplateRenderer.
+
 ```c#
 public class SfDataGridBehavior : Behavior<SfDataGrid>
 {


### PR DESCRIPTION
How to navigate to the multiple controls loaded in GridTemplateColumn by Tab Key in WPF DataGrid (SfDataGrid)?